### PR TITLE
iso_fortran_env for real*8 and integer*4

### DIFF
--- a/example/fsimple.f
+++ b/example/fsimple.f
@@ -21,7 +21,7 @@ C
 C     Compile with: gfortran fsimple.f -o fsimple -L../lib/ -lwigxjpf
 
       program fsimple
-
+      use, intrinsic :: iso_fortran_env, only: spi=>int32, dpf=>real64
 C     Module with function interface declarations.
       use fwigxjpf
       
@@ -32,7 +32,7 @@ C     the module fwigxjpf)
 C     real*8 fwig3jj, fwig6jj, fwig9jj
 
 C     Local variables
-      real*8 val3j, val6j, val9j
+      real(dpf) val3j, val6j, val9j
 
       write (*,"(A)") "WIGXJPF fortran test program"
 

--- a/src/fwigxjpf.f
+++ b/src/fwigxjpf.f
@@ -1,4 +1,5 @@
       module fwigxjpf
+      use, intrinsic :: iso_fortran_env, only: spi=>int32, dpf=>real64
       implicit none
 
       interface
@@ -6,15 +7,18 @@
 C     Initialisation
 
       subroutine fwig_table_init(max_two_j, wigner_type)
-      integer*4 max_two_j, wigner_type
+      use, intrinsic :: iso_fortran_env, only: spi=>int32, dpf=>real64
+      integer(spi) max_two_j, wigner_type
       end subroutine
 
       subroutine fwig_temp_init(max_two_j)
-      integer*4 max_two_j
+      use, intrinsic :: iso_fortran_env, only: spi=>int32, dpf=>real64
+      integer(spi) max_two_j
       end subroutine
 
       subroutine fwig_thread_temp_init(max_two_j)
-      integer*4 max_two_j
+      use, intrinsic :: iso_fortran_env, only: spi=>int32, dpf=>real64
+      integer(spi) max_two_j
       end subroutine
 
 C     Release
@@ -29,16 +33,18 @@ C     3j
 
       function fwig3jj(two_j1, two_j2, two_j3,
      *                 two_m1, two_m2, two_m3)
-      real*8 fwig3jj
-      integer*4 two_j1, two_j2, two_j3, two_m1, two_m2, two_m3
+      use, intrinsic :: iso_fortran_env, only: spi=>int32, dpf=>real64
+      real(dpf) fwig3jj
+      integer(spi) two_j1, two_j2, two_j3, two_m1, two_m2, two_m3
       end function
 
 C     6j
 
       function fwig6jj(two_j1, two_j2, two_j3,
      *                 two_j4, two_j5, two_j6)
-      real*8 fwig6jj
-      integer*4 two_j1, two_j2, two_j3, two_j4, two_j5, two_j6
+      use, intrinsic :: iso_fortran_env, only: spi=>int32, dpf=>real64
+      real(dpf) fwig6jj
+      integer(spi) two_j1, two_j2, two_j3, two_j4, two_j5, two_j6
       end function
 
 C     9j
@@ -46,8 +52,9 @@ C     9j
       function fwig9jj(two_j1, two_j2, two_j3,
      *                 two_j4, two_j5, two_j6,
      *                 two_j7, two_j8, two_j9)
-      real*8 fwig9jj
-      integer*4 two_j1, two_j2, two_j3, two_j4, two_j5, two_j6,
+      use, intrinsic :: iso_fortran_env, only: spi=>int32, dpf=>real64
+      real(dpf) fwig9jj
+      integer(spi) two_j1, two_j2, two_j3, two_j4, two_j5, two_j6,
      *          two_j7, two_j8, two_j9
       end function
 


### PR DESCRIPTION
use, intrinsic :: iso_fortran_env, only: spi=>int32, dpf=>real64